### PR TITLE
make home path dynamic / do not overwrite details of existing users

### DIFF
--- a/sift/config/user/user.sls
+++ b/sift/config/user/user.sls
@@ -1,6 +1,6 @@
 {%- set user = salt['pillar.get']('sift_user', 'sansforensics') -%}
 {%- set all_users = salt['user.list_users']() -%}
-{%- if '{{ user }}' in all_users -%}
+{%- if user in all_users -%}
 {{ user }}:
   user.present:
     - home: /home/{{ user }}

--- a/sift/config/user/user.sls
+++ b/sift/config/user/user.sls
@@ -1,5 +1,10 @@
 {%- set user = salt['pillar.get']('sift_user', 'sansforensics') -%}
-
+{%- set all_users = salt['user.list_users']() -%}
+{%- if '{{ user }}' in all_users -%}
+{{ user }}:
+  user.present:
+    - home: /home/{{ user }}
+{%- else -%}
 {{ user }}:
   user.present:
     - fullname: SANS Forensics
@@ -7,3 +12,4 @@
     - home: /home/{{ user }}
     - password: $1$SZx86ctM$lcEicO1qXvwPG.lhXEvgd.
     - gid_from_name: True
+{%- endif -%}

--- a/sift/config/user/user.sls
+++ b/sift/config/user/user.sls
@@ -4,6 +4,6 @@
   user.present:
     - fullname: SANS Forensics
     - shell: /bin/bash
-    - home: /home/sansforensics
+    - home: /home/{{ user }}
     - password: $1$SZx86ctM$lcEicO1qXvwPG.lhXEvgd.
     - gid_from_name: True


### PR DESCRIPTION
the home path definition was hard-coded, now uses the variable user.

required if you create a pillar with custom variable definition for the username.