### PR TITLE
Correct keyserver path

### DIFF
--- a/sift/repos/docker.sls
+++ b/sift/repos/docker.sls
@@ -9,7 +9,7 @@ docker:
     - dist: ubuntu-{{ grains['lsb_distrib_codename'] }}
     - file: /etc/apt/sources.list.d/docker.list
     - keyid: 58118E89F3A912897C070ADBF76221572C52609D
-    - keyserver: p80.pool.sks-keyservers.net
+    - keyserver: hkp://p80.pool.sks-keyservers.net:80
     - refresh_db: true
     - require:
       - pkg: python-software-properties


### PR DESCRIPTION
While attempting to install SIFT on a fresh install of Ubuntu 16.04.02 under VirtualBox 5.1.18 r114002 it was discovered that the keyserver for the docker repo was unavailable.  Specifically this error message is always returned when `sudo salt-call --local --file-root=/tmp/salt state.sls sift` is run:
```
[ERROR   ] Command '['apt-key', 'adv', '--keyserver', 'p80.pool.sks-keyservers.net', '--logger-fd', '1', '--recv-keys', '58118E89F3A912897C070ADBF76221572C52609D']' failed with return code: 2
[ERROR   ] stdout: Executing: /tmp/tmp.7bQXCDbzsA/gpg.1.sh --keyserver
p80.pool.sks-keyservers.net
--logger-fd
1
--recv-keys
58118E89F3A912897C070ADBF76221572C52609D
gpg: requesting key 2C52609D from hkp server p80.pool.sks-keyservers.net
gpg: keyserver timed out
gpg: keyserver receive failed: keyserver error
[ERROR   ] retcode: 2
[ERROR   ] Failed to configure repo 'deb https://apt.dockerproject.org/repo ubuntu-xenial main': Error: key retrieval failed: Executing: /tmp/tmp.7bQXCDbzsA/gpg.1.sh --keyserver
p80.pool.sks-keyservers.net
--logger-fd
1
--recv-keys
58118E89F3A912897C070ADBF76221572C52609D
gpg: requesting key 2C52609D from hkp server p80.pool.sks-keyservers.net
gpg: keyserver timed out
gpg: keyserver receive failed: keyserver error
```
This appears to be an error with the keyserver path in `sift-saltstack/sift/repos/docker.sls`
```
...
    - keyid: 58118E89F3A912897C070ADBF76221572C52609D
    - keyserver: p80.pool.sks-keyservers.net
    - refresh_db: true
...
```
Fix was to use the recommended path provided by [Saltstack Formulas](https://github.com/saltstack-formulas/docker-formula/blob/master/docker/init.sls) and change as follows
```
...
    - keyid: 58118E89F3A912897C070ADBF76221572C52609D
    - keyserver: hkp://p80.pool.sks-keyservers.net:80
    - refresh_db: true
...
```
Closes #145